### PR TITLE
Chore: Remove Explainer metadata

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -8,7 +8,6 @@ TR: https://www.w3.org/TR/fetch-metadata/
 ED: https://github.com/w3c/webappsec-fetch-metadata/
 Previous Version: https://www.w3.org/TR/2019/WD-fetch-metadata-20200110/
 Editor: Mike West 56384, Google Inc., mkwst@google.com
-!Explainer: <https://github.com/w3c/webappsec-fetch-metadata>
 Abstract:
     This document defines a set of Fetch metadata request headers that aim to provide servers with
     enough information to make <i lang="la">a priori</i> decisions about whether or not to service


### PR DESCRIPTION
The markdown style link gets mangled by Bikeshed, and it doesn't point to a specific Explainer document