### PR TITLE
Update URL of ED

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -5,7 +5,7 @@ Level: None
 Group: webappsec
 Status: WD
 TR: https://www.w3.org/TR/fetch-metadata/
-ED: https://github.com/w3c/webappsec-fetch-metadata/
+ED: https://w3c.github.io/webappsec-fetch-metadata/
 Previous Version: https://www.w3.org/TR/2020/WD-fetch-metadata-20200110/
 Editor: Mike West 56384, Google Inc., mkwst@google.com
 Abstract:


### PR DESCRIPTION
The link to the Editor's Draft in the front matter should target the Editor's Draft, not the GitHub repository.