### PR TITLE
Editorial: Use "Previous Version: from biblio"

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -6,7 +6,7 @@ Group: webappsec
 Status: WD
 TR: https://www.w3.org/TR/fetch-metadata/
 ED: https://w3c.github.io/webappsec-fetch-metadata/
-Previous Version: https://www.w3.org/TR/2020/WD-fetch-metadata-20200110/
+Previous Version: from biblio
 Editor: Mike West 56384, Google Inc., mkwst@google.com
 Abstract:
     This document defines a set of Fetch metadata request headers that aim to provide servers with


### PR DESCRIPTION
This change causes Bikeshed to automatically set the value of the "Previous Version" metadata/link. Otherwise, if we hardcode it, autopublishing (Echidna) fails with a "latest-is-not-previous" error saying, "Retrieved 'previous' and 'latest' documents, but their contents don't match."